### PR TITLE
Inform users about having to DL+Build (not just DL!)

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,8 @@
         <div class="row">
             <div class="col-lg-12 text-center">
                 <h3 id="git-hold" class="section-subheading">
-                    Download the library from GitHub <a
+                    Download the library from GitHub<br>
+                    + build with Gradle (for v>9.x.x)<a
                         href="https://github.com/jfoenixadmin/JFoenix"> <img
                         id="github" src="assets/img/download.svg" id="download">
                 </a>


### PR DESCRIPTION
I spent a bit too long figuring out why I couldn't use the the JFoenix library (for JDK11, latest JFoenix). I then realised I had to build a .jar from the Github source. This could be provided as a release in Github (+ linked in readme).
I took the website instructions too literally (though they made sense for v 9.x.x and below) and hope I can save other people some time by making the process clearer